### PR TITLE
Dockerimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,4 @@ RUN pip install --no-index /src/
 # stuff that will configure and run the tests
 ADD docker/inventory-example.yml /src/inventory-example.yml
 ADD docker/geninventory.py /usr/local/bin/geninventory
-CMD cd /src/ && geninventory && nosetests -vs tests/general_tests/
+CMD cd /src/ && geninventory && nosetests -vs

--- a/docker/inventory-example.yml
+++ b/docker/inventory-example.yml
@@ -89,27 +89,3 @@ ROLES:
       feed: "http://repos.fedorapeople.org/repos/pulp/pulp/demo_repos/zoo/"
       display_name: ZOo rEPO
       tags: ['default', 'small', 'demo']
-  consumers:
-  - &MY_CONSUMER
-    id: my_consumer
-    hostname: consumer.example.com
-    ssh_key:  /home/user/.ssh/id_rsa
-    verify: True/False or can be left empty
-    ca_path: path to the cert on the real consumer
-    os:
-      name: Fedora
-      version: 20
-    repos:
-    - *ZOO
-    pulp: *PULP
-    tags: ['default']
-  nodes:
-    - &node_01
-      auth: [admin, admin]
-      hostname: pulp-node-01.example.com
-      url: 'https://pulp-node-01.example.com'
-      verify_api_ssl: false
-      display_name: pulp-node-01
-      description: 'the pulp node 01 of the example.com domain'
-      pulp: *PULP
-      QPID: *QPID


### PR DESCRIPTION
Hi Michael,
most of the test failures were caused by invalid consumer role in the inventory: `consumer.example.com`
I've removed that role. Now real-consumer test cases should be skipped dynamically.
I've also removed the test restriction --- now even the fake consumer test cases should be run.
This might compensate  the skipped real-consumer cases to some extent.
 Couple of EventListener testcases are failing still, but that's expected --- related Pulp bugs were closed as wontfix so those tests need an expected failure decorator (will fix that in RedHatQE master later).
Would you consider creating a pull request on the RedHatQE repo?

Thanks,
milan
